### PR TITLE
TextArea does not refresh when Text Change until lost of focus. Manually lose focus on File Load and Create New File

### DIFF
--- a/Editor/NotepadModel.cs
+++ b/Editor/NotepadModel.cs
@@ -115,6 +115,7 @@ namespace Plugins.Machination.Notepad
                 {
                     Text = File.ReadAllText(fullPath);
                     HasUnsavedChanges = false;
+                    GUI.FocusControl(null);
                     _view.ModelUpdated();
                     return;
                 }
@@ -142,6 +143,7 @@ namespace Plugins.Machination.Notepad
                 FilePath = newFileName;
                 Text = "";
                 HasUnsavedChanges = false;
+                GUI.FocusControl(null);
                 _view.ModelUpdated();
             }
             else


### PR DESCRIPTION

Current Solution: Hacked Model to lose Focus when LoadTextFromFile and CreateNewFile